### PR TITLE
feat. 요약 다이얼로그 버튼 추가

### DIFF
--- a/src/components/SummaryDialog.vue
+++ b/src/components/SummaryDialog.vue
@@ -1,0 +1,236 @@
+<template>
+  <div v-if="isVisible" class="dialog-overlay" @click="closeDialog">
+    <div class="dialog-content" @click.stop>
+      <div class="dialog-header">
+        <button class="close-btn" @click="closeDialog">&times;</button>
+      </div>
+
+      <div class="dialog-body">
+        <div class="post-info">
+          <h2 class="dialog-title">{{ post.title }}</h2>
+          <div class="post-meta">
+            <div class="company-info">
+              <img :src="getCompanyLogo(post.techBlogEnum)" alt="Company Logo" class="company-logo" />
+              <span class="company-name">{{ post.techBlogEnum }}</span>
+            </div>
+            <time class="publish-date">{{ formatDate(post.publishedDateTime) }}</time>
+          </div>
+        </div>
+
+        <div class="summary-section">
+          <h3>요약</h3>
+          <div class="summary-content">
+            {{ post.summary || '요약 정보가 없습니다.' }}
+          </div>
+        </div>
+
+        <div class="dialog-actions">
+          <button class="original-btn" @click="openOriginal">원문보기</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent, type PropType} from 'vue';
+import {formatDate} from '@/common/utils/dateUtils';
+import kakaoLogo from '@/assets/company/logo/kakao.png';
+import naverLogo from '@/assets/company/logo/naver.png';
+import type {Post} from "@/types/Post";
+
+export default defineComponent({
+  name: 'SummaryDialog',
+  props: {
+    isVisible: {
+      type: Boolean,
+      required: true
+    },
+    post: {
+      type: Object as PropType<Post>,
+      required: true
+    }
+  },
+  emits: ['close'],
+  methods: {
+    formatDate,
+    closeDialog() {
+      this.$emit('close');
+    },
+    openOriginal() {
+      window.open(this.post.url, '_blank');
+      this.closeDialog()
+    },
+    getCompanyLogo(techBlogEnum: string) {
+      const logoMap: { [key: string]: string } = {
+        KAKAO: kakaoLogo,
+        NAVER: naverLogo,
+      };
+      return logoMap[techBlogEnum] || '@/assets/logo.svg';
+    }
+  }
+});
+</script>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.dialog-content {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  font-family: 'Spoqa Han Sans', sans-serif;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 15px 20px 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.close-btn:hover {
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+.dialog-body {
+  padding: 0 20px 20px;
+}
+
+.post-info {
+  margin-bottom: 25px;
+}
+
+.dialog-title {
+  font-size: 1.4em;
+  font-weight: 600;
+  margin: 0 0 15px 0;
+  line-height: 1.4;
+  color: #333;
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.company-info {
+  display: flex;
+  align-items: center;
+}
+
+.company-logo {
+  width: 20px;
+  height: auto;
+  margin-right: 8px;
+}
+
+.company-name {
+  font-size: 0.9em;
+  color: #666;
+  font-weight: 500;
+}
+
+.publish-date {
+  font-size: 0.9em;
+  color: #666;
+}
+
+.summary-section {
+  margin-bottom: 25px;
+}
+
+.summary-section h3 {
+  font-size: 1.1em;
+  margin: 0 0 15px 0;
+  color: #333;
+  font-weight: 600;
+}
+
+.summary-content {
+  background-color: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  line-height: 1.6;
+  color: #555;
+  border-left: 4px solid #1a73e8;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.original-btn {
+  background-color: #1a73e8;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9em;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.original-btn:hover {
+  background-color: #1557b0;
+}
+
+/* 모바일 반응형 */
+@media (max-width: 768px) {
+  .dialog-content {
+    width: 95%;
+    max-height: 90vh;
+    margin: 20px;
+  }
+
+  .dialog-title {
+    font-size: 1.2em;
+  }
+
+  .post-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .summary-content {
+    padding: 12px;
+  }
+}
+</style>

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,0 +1,9 @@
+export interface Post {
+  techBlogPostSeq: number;
+  title: string;
+  url: string;
+  techBlogEnum: string;
+  publishedDateTime: string;
+  summary?: string;
+}
+

--- a/src/views/TechBlogPost.vue
+++ b/src/views/TechBlogPost.vue
@@ -12,13 +12,23 @@
               <div class="company-info">
                 <img :src="getCompanyLogo(post.techBlogEnum)" alt="Company Logo" class="company-logo" />
                 <span class="card-company">{{ post.techBlogEnum }}</span>
-                <time class="card-date">{{ formatDate(post.publishedDateTime) }}</time>
+                <div class="date-section">
+                  <button class="summary-btn" @click="openSummaryDialog(post)">요약본 보기</button>
+                  <time class="card-date">{{ formatDate(post.publishedDateTime) }}</time>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
+
+    <!-- Summary Dialog -->
+    <SummaryDialog
+      :isVisible="showSummaryDialog"
+      :post="selectedPost"
+      @close="closeSummaryDialog"
+    />
   </div>
 </template>
 
@@ -29,18 +39,25 @@ import { formatDate } from '@/common/utils/dateUtils';
 import eventBus from '@/common/eventBus';
 import kakaoLogo from '@/assets/company/logo/kakao.png';
 import naverLogo from '@/assets/company/logo/naver.png';
+import SummaryDialog from '@/components/SummaryDialog.vue';
+import type { Post } from '@/types/Post';
 
 export default defineComponent({
   name: 'TechBlogPost',
+  components: {
+    SummaryDialog
+  },
   methods: { formatDate },
   setup() {
-    const posts = ref<any[]>([]);
+    const posts = ref<Post[]>([]);
     const loading = ref(true);
     const currentPage = ref(1);
     const pageSize = ref(100);
     const totalPages = ref(0);
     const searchQuery = ref('');
     const isFetching = ref(false);
+    const showSummaryDialog = ref(false);
+    const selectedPost = ref<Post>({} as Post);
 
     const handleScroll = () => {
       const scrollPosition = window.innerHeight + window.scrollY;
@@ -102,10 +119,28 @@ export default defineComponent({
         KAKAO: kakaoLogo,
         NAVER: naverLogo,
       };
-      return logoMap[techBlogEnum] || '@/assets/log.svg';
+      return logoMap[techBlogEnum] || '@/assets/logo.svg';
     };
 
-    return { posts, loading, getCompanyLogo };
+    const openSummaryDialog = (post: Post) => {
+      selectedPost.value = post;
+      showSummaryDialog.value = true;
+    };
+
+    const closeSummaryDialog = () => {
+      showSummaryDialog.value = false;
+      selectedPost.value = {} as Post;
+    };
+
+    return {
+      posts,
+      loading,
+      getCompanyLogo,
+      showSummaryDialog,
+      selectedPost,
+      openSummaryDialog,
+      closeSummaryDialog
+    };
   },
 });
 </script>
@@ -184,10 +219,32 @@ export default defineComponent({
   letter-spacing: 0; /* 글자 간격 조정 */
 }
 
+.date-section {
+  display: flex;
+  align-items: center;
+  gap: 15px; /* 요약본 보기 버튼과 날짜 사이 간격 */
+  margin-left: auto; /* 우측 정렬 */
+}
+
+.summary-btn {
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  white-space: nowrap;
+}
+
+.summary-btn:hover {
+  background-color: #4b5563;
+}
+
 .card-date {
   font-size: 1em; /* 날짜 크기 조정 */
   color: #666;
-  margin-left: auto; /* 날짜를 우측으로 정렬 */
   letter-spacing: 0; /* 글자 간격 조정 */
 }
 
@@ -211,6 +268,17 @@ export default defineComponent({
 
   .card-company {
     font-size: 0.85em;
+  }
+
+  .date-section {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  .summary-btn {
+    font-size: 0.8em;
+    padding: 5px 10px;
   }
 
   .card-date {


### PR DESCRIPTION
요약 다이얼로그 버튼을 추가합니다.
<img width="1030" height="108" alt="image" src="https://github.com/user-attachments/assets/6acfe6f6-eeaf-4ab6-afee-5712a70bc734" />

클릭시 요약본 보기 다이얼로그가 활성화 됩니다.

<img width="1887" height="841" alt="image" src="https://github.com/user-attachments/assets/6bed5db8-e63f-4069-b0b5-19a521313f64" />

원문보기 버튼 클릭시 원문으로 링크 이동합니다.
